### PR TITLE
Fix noInteraction option description typo

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -34,7 +34,7 @@ program
   .option('-n, --noClean', 'Prevent cleaning up old output files', false)
   .option(
     '-i, --noInteraction',
-    'Execute in non-interactive mode. Lock file must exist; any non-present value will be pass as empty.',
+    'Execute in non-interactive mode. Lock file must exist; any non-present value will be passed as empty.',
     false
   )
   .option('-q, --quiet', 'Execute in silent mode', false)


### PR DESCRIPTION
## Summary
- fix a typo in the `--noInteraction` option description

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68454667b06883218ca013ea3f5e8707