### PR TITLE
Add rejection assertion for feasible init

### DIFF
--- a/test/01-init.spec.js
+++ b/test/01-init.spec.js
@@ -1,11 +1,15 @@
-import {
+import chai, {
   should,
   // eslint-disable-next-line no-unused-vars
   expect
 } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
 
 // eslint-disable-next-line no-unused-vars
 import { feasible } from '../lib/index.js';
+
+chai.use(chaiAsPromised);
 
 should();
 
@@ -13,7 +17,7 @@ describe('feasible', () => {
   it('should be rejected without configuration', () => {
     // return expect(feasible()).to.be.an('object');
     // return feasible().should.be.rejectedWith("Cannot read properties of undefined (reading 'actions')");
-    return true;
+    return feasible().should.be.rejected;
   });
   // it('should be rejected for unsupported conf file', () => {
   //   return feasible({ config: './test/scenarios/00-unsupported.toml' }).should.be.rejectedWith(


### PR DESCRIPTION
## Summary
- confirm feasible() rejects without configuration using promise assertion

## Testing
- `npm test` *(fails: `mocha: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845467060a48321a82a70069ed850d3