### PR TITLE
Fix error message quotes in utils

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -150,7 +150,7 @@ function replaceVariableInString (file, vars, separator) {
       const escape = variable.includes('.unescape');
       const genVar = vars[variable.replace('.val', '').replace('.unescape', '')];
       if (genVar === undefined) {
-        throw new Error(`Variable "${variable} not found in the variables list`);
+        throw new Error(`Variable "${variable}" not found in the variables list`);
       }
       file = replaceAll(file, uniqueVariable, genVar.toString().includes(' ') && !escape ? `'${genVar}'` : genVar);
     } else if (variable.endsWith('.name') && variable.replace('.name', '') in vars) {
@@ -159,7 +159,7 @@ function replaceVariableInString (file, vars, separator) {
       file = replaceAll(file, uniqueVariable, process.env[variable.replace('.env', '')]);
     } else {
       if (vars[variable] === undefined) {
-        throw new Error(`Variable "${variable} not found in the variables list`);
+        throw new Error(`Variable "${variable}" not found in the variables list`);
       }
       const genVar = vars[variable].toString().includes(' ') ? `'${vars[variable]}'` : vars[variable];
       file = replaceAll(file, uniqueVariable, [variable, genVar].join(separator));


### PR DESCRIPTION
## Summary
- fix typo in replaceVariableInString error throws

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845466a25d08321b0210f7976a9ed73