### PR TITLE
Add coverage generation to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,3 +20,9 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm test
+      - name: Generate coverage report
+        run: npx c8 --reporter=text --reporter=lcov npm test
+      - uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - run: npm test
       - name: Generate coverage report
         run: npx c8 --reporter=text --reporter=lcov npm test
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,8 @@ jobs:
           node-version: 20
       - run: npm ci
       - run: npm run lint
-      - run: npm test
-      - name: Generate coverage report
-        run: npx c8 --reporter=text --reporter=lcov npm test
+      - name: Run tests with coverage
+        run: npm run coverage
       - uses: actions/upload-artifact@v4
         with:
           name: coverage

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "test": "mocha",
+    "coverage": "c8 --reporter=text --reporter=lcov npm test",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },
@@ -47,7 +48,8 @@
     "eslint-plugin-import": "2.31.0",
     "eslint-plugin-n": "16.6.2",
     "eslint-plugin-promise": "6.6.0",
-    "mocha": "11.1.0"
+    "mocha": "11.1.0",
+    "c8": "10.1.3"
   },
   "eslintConfig": {
     "env": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "mocha",
-    "coverage": "c8 --reporter=text --reporter=lcov npm test",
+    "coverage": "npx c8 --reporter=text --reporter=lcov npm test",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },
@@ -48,8 +48,7 @@
     "eslint-plugin-import": "2.31.0",
     "eslint-plugin-n": "16.6.2",
     "eslint-plugin-promise": "6.6.0",
-    "mocha": "11.1.0",
-    "c8": "10.1.3"
+    "mocha": "11.1.0"
   },
   "eslintConfig": {
     "env": {


### PR DESCRIPTION
## Summary
- update CI workflow to generate and upload coverage report

## Testing
- `npm test` *(fails: `mocha` not found)*
- `npm ci` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68456067d48483219c6d6414575f4eb8